### PR TITLE
Update core-conf.el

### DIFF
--- a/core/core-conf.el
+++ b/core/core-conf.el
@@ -18,9 +18,10 @@
 ;; see <https://www.gnu.org/licenses/>.
 
 ;; load core config.
+(load-library "straight")
 (load-library "backup")
 (load-library "emacs")
 (load-library "recentfile")
 (load-library "settings")
-(load-library "straight")
+
 (load-library "which-key")


### PR DESCRIPTION
straight needs to be imported first, otherwise initial initialization fails as use-package is unknown.